### PR TITLE
TF refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,4 +171,4 @@ venv.bak/
 # Custom stuff
 .idea
 local
-tmp.py
+.DS_Store

--- a/examples/addition_rnn.py
+++ b/examples/addition_rnn.py
@@ -23,8 +23,9 @@ BATCH_SIZE = 50
 
 
 def main():
-  # Generate the dataset directly in the computational graph
-  inputs, targets = get_batch_variables()
+  # Placeholders for training data
+  inputs_ph = tf.placeholder(tf.float32, shape=(BATCH_SIZE, TIME_STEPS, 2))
+  targets_ph = tf.placeholder(tf.float32, shape=BATCH_SIZE)
 
   # Build the graph
   cell = tf.nn.rnn_cell.MultiRNNCell([
@@ -33,7 +34,7 @@ def main():
   ])
   # cell = tf.nn.rnn_cell.BasicLSTMCell(NUM_UNITS) uncomment this for LSTM runs
 
-  output, state = tf.nn.dynamic_rnn(cell, inputs, dtype=tf.float32)
+  output, state = tf.nn.dynamic_rnn(cell, inputs_ph, dtype=tf.float32)
   last = output[:, -1, :]
 
   weight = tf.get_variable("softmax_weight", shape=[NUM_UNITS, 1])
@@ -41,7 +42,7 @@ def main():
                          initializer=tf.constant_initializer(0.1))
   prediction = tf.squeeze(tf.matmul(last, weight) + bias)
 
-  loss_op = tf.losses.mean_squared_error(tf.squeeze(targets), prediction)
+  loss_op = tf.losses.mean_squared_error(tf.squeeze(targets_ph), prediction)
 
   global_step = tf.get_variable("global_step", shape=[], trainable=False,
                                 initializer=tf.zeros_initializer)
@@ -58,29 +59,32 @@ def main():
     while True:
       losses = []
       for _ in range(100):
-        loss, _ = sess.run([loss_op, optimize])
+        # Generate new input data
+        inputs, targets = get_batch()
+        loss, _ = sess.run([loss_op, optimize],
+                           {inputs_ph: inputs, targets_ph: targets})
         losses.append(loss)
         step += 1
       print("Step [x100] {} MSE {}".format(int(step / 100), np.mean(losses)))
 
 
-def get_batch_variables():
-  """Generate the adding problem dataset in the computational graph"""
-  input_values = tf.random_uniform([BATCH_SIZE, TIME_STEPS])
+def get_batch():
+  """Generate the adding problem dataset"""
+  # Build the first sequence
+  add_values = np.random.rand(BATCH_SIZE, TIME_STEPS)
 
-  # Build the input indices by choosing two random integers (one per half) and
-  # concatenating their one-hot-encodings
+  # Build the second sequence with one 1 in each half and 0s otherwise
+  add_indices = np.zeros_like(add_values)
   half = int(TIME_STEPS / 2)
-  input_index_first = tf.random_uniform([BATCH_SIZE], 0, half - 1, tf.int32)
-  input_index_second = tf.random_uniform([BATCH_SIZE], 0, half - 1, tf.int32)
-  input_indices = tf.concat([tf.one_hot(input_index_first, half),
-                              tf.one_hot(input_index_second, half)], axis=1)
+  for i in range(BATCH_SIZE):
+    first_half = np.random.randint(half)
+    second_half = np.random.randint(half, TIME_STEPS)
+    add_indices[i, [first_half, second_half]] = 1
 
-  targets = tf.reduce_sum(tf.multiply(input_values, input_indices), axis=1)
   # Zip the values and indices in a third dimension:
-  inputs = tf.stack([input_values, input_indices], axis=-1)
   # inputs has the shape (batch_size, time_steps, 2)
-
+  inputs = np.dstack((add_values, add_indices))
+  targets = np.sum(np.multiply(add_values, add_indices), axis=1)
   return inputs, targets
 
 

--- a/ind_rnn_cell.py
+++ b/ind_rnn_cell.py
@@ -1,4 +1,5 @@
 """Module implementing the IndRNN cell"""
+
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import init_ops
 from tensorflow.python.ops import nn_ops
@@ -8,24 +9,29 @@ from tensorflow.python.layers import base as base_layer
 
 
 class IndRNNCell(rnn_cell_impl._LayerRNNCell):
-  """Independently RNN Cell. Adapted from `rnn_cell_impl.BasicRNNCell
+  """Independently RNN Cell. Adapted from `rnn_cell_impl.BasicRNNCell`.
 
   The implementation is based on:
+
     https://arxiv.org/abs/1803.04831
-    Shuai Li, Wanqing Li, Chris Cook, Ce Zhu, Yanbo Gao
-    "Independently Recurrent Neural Network (IndRNN): Building A Longer and
-      Deeper RNN"
+
+  Shuai Li, Wanqing Li, Chris Cook, Ce Zhu, Yanbo Gao
+  "Independently Recurrent Neural Network (IndRNN): Building A Longer and
+  Deeper RNN"
+
+  Each unit has a single recurrent weight connected to its last hidden state.
 
   Args:
     num_units: int, The number of units in the RNN cell.
     recurrent_min_abs: float, minimum absolute value of each recurrent weight.
-    recurrent_max_abs: float or None, maximum absolute value of each recurrent
-      weight. For ReLU activation, pow(2, 1/timesteps) is recommended. If None,
-      recurrent weights will not be clipped. Default: None.
+    recurrent_max_abs: (optional) float, maximum absolute value of each
+      recurrent weight. For `relu` activation, `pow(2, 1/timesteps)` is
+      recommended. If None, recurrent weights will not be clipped.
+      Default: None.
     recurrent_initializer: (optional) The initializer to use for the recurrent
-      weights. The default is a uniform distribution in the range [-1, 1] if
-      `recurrent_max_abs` is not set, or in [-recurrent_max_abs,
-      recurrent_max_abs] if it is.
+      weights. The default is a uniform distribution in the range `[-1, 1]` if
+      `recurrent_max_abs` is not set, or in
+      `[-recurrent_max_abs, recurrent_max_abs]` if it is.
     activation: Nonlinearity to use.  Default: `relu`.
     reuse: (optional) Python boolean describing whether to reuse variables
       in an existing scope.  If not `True`, and the existing scope already has
@@ -64,54 +70,68 @@ class IndRNNCell(rnn_cell_impl._LayerRNNCell):
 
     input_depth = inputs_shape[1].value
     self._input_kernel = self.add_variable(
-      "input_%s" % rnn_cell_impl._WEIGHTS_VARIABLE_NAME,
-      shape=[input_depth, self._num_units])
+        "input_kernel",
+        shape=[input_depth, self._num_units])
 
     if self._recurrent_initializer is None:
       if self._recurrent_max_abs:
         self._recurrent_initializer = init_ops.random_uniform_initializer(
-          minval=-self._recurrent_max_abs,
-          maxval=self._recurrent_max_abs
+            minval=-self._recurrent_max_abs,
+            maxval=self._recurrent_max_abs
         )
       else:
         self._recurrent_initializer = init_ops.random_uniform_initializer(
-          minval=-1.0,
-          maxval=1.0
+            minval=-1.0,
+            maxval=1.0
         )
 
     self._recurrent_kernel = self.add_variable(
-      "recurrent_%s" % rnn_cell_impl._WEIGHTS_VARIABLE_NAME,
-      shape=[self._num_units], initializer=self._recurrent_initializer)
+        "recurrent_kernel",
+        shape=[self._num_units], initializer=self._recurrent_initializer)
 
-    # Clip the absolute values of the recurrent weights
+    # Clip the absolute values of the recurrent weights to the specified minimum
     if self._recurrent_min_abs:
       abs_kernel = math_ops.abs(self._recurrent_kernel)
       min_abs_kernel = math_ops.maximum(abs_kernel, self._recurrent_min_abs)
       self._recurrent_kernel = math_ops.multiply(
-        math_ops.sign(self._recurrent_kernel),
-        min_abs_kernel
+          math_ops.sign(self._recurrent_kernel),
+          min_abs_kernel
       )
 
+    # Clip the absolute values of the recurrent weights to the specified maximum
     if self._recurrent_max_abs:
       self._recurrent_kernel = clip_ops.clip_by_value(self._recurrent_kernel,
                                                       -self._recurrent_max_abs,
                                                       self._recurrent_max_abs)
 
     self._bias = self.add_variable(
-      rnn_cell_impl._BIAS_VARIABLE_NAME,
-      shape=[self._num_units],
-      initializer=init_ops.zeros_initializer(dtype=self.dtype))
+        "bias",
+        shape=[self._num_units],
+        initializer=init_ops.zeros_initializer(dtype=self.dtype))
 
     self.built = True
 
   def call(self, inputs, state):
-    """IndRNN: output = new_state = act(W * input + u (*) state + b),
+    """Run one step of the IndRNN.
 
-    where * is the matrix multiplication and (*) is the Hadamard product.
+    Calculates the output and new hidden state using the IndRNN equation
+
+      `output = new_state = act(W * input + u (*) state + b)`
+
+    , where `*` is the matrix multiplication and `(*)` is the Hadamard product.
+
+    Args:
+      inputs: Tensor, 2-dimensional tensor of shape `[batch, num_units]`.
+      state: Tensor, 2-dimensional tensor of shape `[batch, num_units]`
+        containing the previous hidden state.
+
+    Returns:
+      A tuple containing the output and new hidden state. Both are the same
+        2-dimensional tensor of shape `[batch, num_units]`.
     """
     gate_inputs = math_ops.matmul(inputs, self._input_kernel)
-    gate_inputs = math_ops.add(gate_inputs,
-                               math_ops.multiply(state, self._recurrent_kernel))
+    recurrent_update = math_ops.multiply(state, self._recurrent_kernel)
+    gate_inputs = math_ops.add(gate_inputs, recurrent_update)
     gate_inputs = nn_ops.bias_add(gate_inputs, self._bias)
     output = self._activation(gate_inputs)
     return output, output

--- a/ind_rnn_cell_test.py
+++ b/ind_rnn_cell_test.py
@@ -1,17 +1,20 @@
+"""Tests for the IndRNN cell."""
+
 import numpy as np
 
 from tensorflow.python.ops import variable_scope
 from tensorflow.python.ops import init_ops
 from tensorflow.python.ops import array_ops
-from tensorflow.python.ops import rnn_cell_impl
-from tensorflow.python.ops import variables as variables_lib
+from tensorflow.python.ops import variables
 from tensorflow.python.platform import test
 
 from ind_rnn_cell import IndRNNCell
 
 
-class RNNCellTest(test.TestCase):
+class IndRNNCellTest(test.TestCase):
   def testIndRNNCell(self):
+    """Tests cell with recurrent weights exceeding the bounds."""
+
     with self.test_session() as sess:
       with variable_scope.variable_scope(
           "root", initializer=init_ops.constant_initializer(1.)):
@@ -21,9 +24,10 @@ class RNNCellTest(test.TestCase):
         cell = IndRNNCell(4, recurrent_min_abs=1., recurrent_max_abs=3.,
                           recurrent_initializer=recurrent_init)
         output, _ = cell(x, m)
-        sess.run([variables_lib.global_variables_initializer()])
+        sess.run([variables.global_variables_initializer()])
         res = sess.run([output], {x.name: np.array([[1., 1., 1., 1.]]),
-                                  m.name: np.array([[2., 2., 2., 2.]])})
-        # Recurrent Weights u should be -3, -2, 1, 3
-        # Pre-activations (4 + 2*u) should be -2, 0, 6, 10
+          m.name: np.array([[2., 2., 2., 2.]])})
+        # Recurrent Weights should be -3, -2, 1, 3
+        # (Pre)activations (4 + 2*rec_weight) should be -2, 0, 6, 10
+        # Thus, ReLU outputs should be 0, 0, 6, 10
         self.assertAllEqual(res[0], [[0., 0., 6., 10.]])

--- a/ind_rnn_cell_test.py
+++ b/ind_rnn_cell_test.py
@@ -13,6 +13,24 @@ from ind_rnn_cell import IndRNNCell
 
 class IndRNNCellTest(test.TestCase):
   def testIndRNNCell(self):
+    """Tests basic cell functionality"""
+
+    with self.test_session() as sess:
+      with variable_scope.variable_scope(
+          "root", initializer=init_ops.constant_initializer(1.)):
+        x = array_ops.zeros([1, 4])
+        m = array_ops.zeros([1, 4])
+        recurrent_init = init_ops.constant_initializer([-3., -2., 1., 3.])
+        cell = IndRNNCell(4, recurrent_initializer=recurrent_init,
+                          activation=array_ops.identity)
+        output, _ = cell(x, m)
+        sess.run([variables.global_variables_initializer()])
+        res = sess.run([output], {x.name: np.array([[1., 0., 0., 0.]]),
+          m.name: np.array([[2., 2., 2., 2.]])})
+        # (Pre)activations (1*1 + 2*rec_weight) should be -2, 0, 6, 10
+        self.assertAllEqual(res[0], [[-5., -3., 3., 7.]])
+
+  def testIndRNNCellBounds(self):
     """Tests cell with recurrent weights exceeding the bounds."""
 
     with self.test_session() as sess:
@@ -22,12 +40,12 @@ class IndRNNCellTest(test.TestCase):
         m = array_ops.zeros([1, 4])
         recurrent_init = init_ops.constant_initializer([-5., -2., 0.1, 5.])
         cell = IndRNNCell(4, recurrent_min_abs=1., recurrent_max_abs=3.,
-                          recurrent_initializer=recurrent_init)
+                          recurrent_initializer=recurrent_init,
+                          activation=array_ops.identity)
         output, _ = cell(x, m)
         sess.run([variables.global_variables_initializer()])
-        res = sess.run([output], {x.name: np.array([[1., 1., 1., 1.]]),
+        res = sess.run([output], {x.name: np.array([[1., 0., 0., 0.]]),
           m.name: np.array([[2., 2., 2., 2.]])})
         # Recurrent Weights should be -3, -2, 1, 3
-        # (Pre)activations (4 + 2*rec_weight) should be -2, 0, 6, 10
-        # Thus, ReLU outputs should be 0, 0, 6, 10
-        self.assertAllEqual(res[0], [[0., 0., 6., 10.]])
+        # (Pre)activations (1*1 + 2*rec_weight) should be -2, 0, 6, 10
+        self.assertAllEqual(res[0], [[-5., -3., 3., 7.]])

--- a/ind_rnn_cell_test.py
+++ b/ind_rnn_cell_test.py
@@ -20,14 +20,19 @@ class IndRNNCellTest(test.TestCase):
           "root", initializer=init_ops.constant_initializer(1.)):
         x = array_ops.zeros([1, 4])
         m = array_ops.zeros([1, 4])
+
+        # Create the cell with input weights = 1 and constant recurrent weights
         recurrent_init = init_ops.constant_initializer([-3., -2., 1., 3.])
-        cell = IndRNNCell(4, recurrent_initializer=recurrent_init,
+        cell = IndRNNCell(4,
+                          recurrent_initializer=recurrent_init,
                           activation=array_ops.identity)
         output, _ = cell(x, m)
+
         sess.run([variables.global_variables_initializer()])
-        res = sess.run([output], {x.name: np.array([[1., 0., 0., 0.]]),
-          m.name: np.array([[2., 2., 2., 2.]])})
-        # (Pre)activations (1*1 + 2*rec_weight) should be -2, 0, 6, 10
+        res = sess.run([output],
+                       {x.name: np.array([[1., 0., 0., 0.]]),
+                         m.name: np.array([[2., 2., 2., 2.]])})
+        # (Pre)activations (1*1 + 2*rec_weight) should be -5, -3, 3, 7
         self.assertAllEqual(res[0], [[-5., -3., 3., 7.]])
 
   def testIndRNNCellBounds(self):
@@ -38,14 +43,20 @@ class IndRNNCellTest(test.TestCase):
           "root", initializer=init_ops.constant_initializer(1.)):
         x = array_ops.zeros([1, 4])
         m = array_ops.zeros([1, 4])
+
+        # Create the cell with input weights = 1 and constant recurrent weights
         recurrent_init = init_ops.constant_initializer([-5., -2., 0.1, 5.])
-        cell = IndRNNCell(4, recurrent_min_abs=1., recurrent_max_abs=3.,
+        cell = IndRNNCell(4,
+                          recurrent_min_abs=1.,
+                          recurrent_max_abs=3.,
                           recurrent_initializer=recurrent_init,
                           activation=array_ops.identity)
         output, _ = cell(x, m)
+
         sess.run([variables.global_variables_initializer()])
-        res = sess.run([output], {x.name: np.array([[1., 0., 0., 0.]]),
-          m.name: np.array([[2., 2., 2., 2.]])})
-        # Recurrent Weights should be -3, -2, 1, 3
-        # (Pre)activations (1*1 + 2*rec_weight) should be -2, 0, 6, 10
+        res = sess.run([output],
+                       {x.name: np.array([[1., 0., 0., 0.]]),
+                         m.name: np.array([[2., 2., 2., 2.]])})
+        # Recurrent weights should be clipped to -3, -2, 1, 3
+        # (Pre)activations (1*1 + 2*rec_weight) should be -5, -3, 3, 7
         self.assertAllEqual(res[0], [[-5., -3., 3., 7.]])


### PR DESCRIPTION
This PR primarily adds documentation and changes the code style to match the TF source. One change in functionality: The recurrent weights are initialized to `[-1, 1]` by default and to `[-recurrent_max_abs, recurrent_max_abs]` only, when `recurrent_max_abx < 1`. The latter case prevents weights larger than 1 being immediately clipped to 1, which disturbs the uniform distribution of initial recurrent weights.